### PR TITLE
deleted baseplate weight

### DIFF
--- a/filemanager/xml_templates/baseplate/cond_upload.xml
+++ b/filemanager/xml_templates/baseplate/cond_upload.xml
@@ -28,7 +28,7 @@
         <DATA>
             <FLATNESS>{{ flatness }}</FLATNESS>
             <THICKNESS>{{ thickness }}</THICKNESS>
-            <WEIGHT>{{ weight }}</WEIGHT>
+            <!-- <WEIGHT>{{ weight }}</WEIGHT> -->
             <GRADE>{{ grade }}</GRADE>
             <COMMENTS>{{ comments_upload }}</COMMENTS>
         </DATA>


### PR DESCRIPTION
MACs no longer need to report the weight of baseplates. 